### PR TITLE
Tlog fix

### DIFF
--- a/lib/tasks/umichwrapper.rake
+++ b/lib/tasks/umichwrapper.rake
@@ -8,9 +8,6 @@ namespace :umich do
     UMichwrapper.clean(UMICH_CONFIG)
   end
 
-  # directory "dist"
-  # directory "config"
-
   desc "Load the umich environment from config."
   task :environment do
     unless defined? UMICH_CONFIG

--- a/lib/umichwrapper.rb
+++ b/lib/umichwrapper.rb
@@ -225,6 +225,7 @@ class UMichwrapper
       sleep 2 # wait for tlogs to be committed
       UMichwrapper.instance.del_core
       UMichwrapper.instance.del_node
+      UMichwrapper.instance.del_core
       return UMichwrapper.instance
     end
 
@@ -294,6 +295,22 @@ class UMichwrapper
     target_url = "#{self.solr_base_url}/#{corename}/update"
     resp = Typhoeus.get(target_url, params: vars)
     body = JSON.parse!(resp.response_body)
+  end
+
+  def commit_pending_tlogs
+    # API call to unload core with Solr instance.
+    vars = {
+      action: "UPDATE",
+      commit: true,
+      wt: "json"}
+
+    target_url = "#{self.solr_admin_url}/#{corename}"
+    resp = Typhoeus.get(target_url, params: vars)
+
+    body = JSON.parse!(resp.response_body)
+
+    binding.pry
+
   end
 
   def corename

--- a/lib/umichwrapper.rb
+++ b/lib/umichwrapper.rb
@@ -280,7 +280,11 @@ class UMichwrapper
     core_inst_dir = File.join( self.solr_home, ENV['USER'], corename )
     logger.info "Deleting dir: #{core_inst_dir}"
 
-    FileUtils.rm_r( core_inst_dir )
+    begin
+      FileUtils.rm_r( core_inst_dir )
+    rescue Errno::ENOENT => my_ex
+      logger.info "#{core_inst_dir} does not exist.  Core already cleaned?"
+    end
   end
 
   # Manually do update with commit=true to force solr to clear the tlogs
@@ -295,7 +299,7 @@ class UMichwrapper
     target_url = "#{self.solr_base_url}/#{corename}/update"
     resp = Typhoeus.get(target_url, params: vars)
     if resp.response_code == 404
-      logger.info "#{target_url} not found.  Already cleaned?"
+      logger.info "#{target_url} not found.  Core already cleaned?"
     else
       body = JSON.parse!(resp.response_body)
     end

--- a/lib/umichwrapper.rb
+++ b/lib/umichwrapper.rb
@@ -225,7 +225,6 @@ class UMichwrapper
       sleep 2 # wait for tlogs to be committed
       UMichwrapper.instance.del_core
       UMichwrapper.instance.del_node
-      UMichwrapper.instance.del_core
       return UMichwrapper.instance
     end
 
@@ -292,9 +291,14 @@ class UMichwrapper
       commit: true,
       wt: "json"}
 
+    logger.info "Commiting solr tlogs."
     target_url = "#{self.solr_base_url}/#{corename}/update"
     resp = Typhoeus.get(target_url, params: vars)
-    body = JSON.parse!(resp.response_body)
+    if resp.response_code == 404
+      logger.info "#{target_url} not found.  Already cleaned?"
+    else
+      body = JSON.parse!(resp.response_body)
+    end
   end
 
   def commit_pending_tlogs

--- a/lib/umichwrapper.rb
+++ b/lib/umichwrapper.rb
@@ -345,15 +345,21 @@ class UMichwrapper
     core_inst_dir = File.join( self.solr_home, ENV['USER'], corename )
 
     logger.debug "Adding solr core #{corename}"
-    # Check if core instance directory already exists
-    cs = core_status
-    instance_dirs =  cs.collect{ |arr| arr[1]["instanceDir"].chop }
+    # Check if core instance already exists according to solr
+    instance_dirs =  core_status.collect{ |arr| arr[1]["instanceDir"].chop }
 
-    # Short circut if core instance directory already exists.
-    if instance_dirs.include? core_inst_dir
-      logger.info "Directory for #{corename} alerady exists."
+    # Check filesystem for instance directory.
+    if File.exist? core_inst_dir
+      logger.warn "Directory #{corename} alerady exists. Core not added."
       return
     end
+    
+    # Check Solr for core.
+    if instance_dirs.include? core_inst_dir
+      logger.warn "Solr core for #{corename} alerady exists. Core not added."
+      return
+    end
+
 
     # File operation to copy dir and files from template
     # Check for solr_cores/corename template in current directory

--- a/lib/umichwrapper/version.rb
+++ b/lib/umichwrapper/version.rb
@@ -1,3 +1,3 @@
 class UMichwrapper
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/solr_cores/dev/conf/solrconfig.xml
+++ b/solr_cores/dev/conf/solrconfig.xml
@@ -25,12 +25,12 @@
     </updateLog>
 
     <autoCommit> 
-      <maxTime>${solr.autoCommit.maxTime:15000}</maxTime> 
+      <maxTime>${solr.autoCommit.maxTime:5000}</maxTime> 
       <openSearcher>false</openSearcher> 
     </autoCommit>
 
     <autoSoftCommit> 
-      <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime> 
+      <maxTime>${solr.autoSoftCommit.maxTime:2500}</maxTime> 
     </autoSoftCommit>
 
   </updateHandler>

--- a/solr_cores/dev/conf/solrconfig.xml
+++ b/solr_cores/dev/conf/solrconfig.xml
@@ -24,8 +24,11 @@
       <str name="dir">${solr.ulog.dir:}</str>
     </updateLog>
 
+    <maxPendingDeletes>10</maxPendingDeletes>
+
     <autoCommit> 
       <maxTime>${solr.autoCommit.maxTime:5000}</maxTime> 
+      <maxDocs>${solr.autoCommit.maxTime:5}</maxDocs> 
       <openSearcher>false</openSearcher> 
     </autoCommit>
 


### PR DESCRIPTION
Instruct solr to commit changes before removing a node.  This should cause solr to remove the tlog files that were previously not removable by users.
